### PR TITLE
Fix: Put Content Type Back In Manually For Slack So It Works With Oauth2 0.6.0

### DIFF
--- a/lib/ueberauth/strategy/slack.ex
+++ b/lib/ueberauth/strategy/slack.ex
@@ -164,7 +164,7 @@ defmodule Ueberauth.Strategy.Slack do
 
   # Before we can fetch the user, we first need to fetch the auth to find out what the user id is.
   defp fetch_auth(conn, token) do
-    case OAuth2.AccessToken.post(token, "/auth.test", token: token.access_token) do
+    case OAuth2.AccessToken.post(token, "/auth.test", [token: token.access_token], [{"Content-Type", "application/x-www-form-urlencoded"}]) do
       { :ok, %OAuth2.Response{status_code: 401, body: _body}} ->
         set_errors!(conn, [error("token", "unauthorized")])
       { :ok, %OAuth2.Response{status_code: status_code, body: auth} } when status_code in 200..399 ->
@@ -186,7 +186,7 @@ defmodule Ueberauth.Strategy.Slack do
   defp fetch_user(conn, token) do
     auth = conn.private.slack_auth
 
-    case OAuth2.AccessToken.post(token, "/users.info", token: token.access_token, user: auth["user_id"]) do
+    case OAuth2.AccessToken.post(token, "/users.info", [token: token.access_token, user: auth], ["user_id"], [{"Content-Type", "application/x-www-form-urlencoded"}]) do
       { :ok, %OAuth2.Response{status_code: 401, body: _body}} ->
         set_errors!(conn, [error("token", "unauthorized")])
       { :ok, %OAuth2.Response{status_code: status_code, body: user} } when status_code in 200..399 ->

--- a/lib/ueberauth/strategy/slack.ex
+++ b/lib/ueberauth/strategy/slack.ex
@@ -186,7 +186,7 @@ defmodule Ueberauth.Strategy.Slack do
   defp fetch_user(conn, token) do
     auth = conn.private.slack_auth
 
-    case OAuth2.AccessToken.post(token, "/users.info", [token: token.access_token, user: auth], ["user_id"], [{"Content-Type", "application/x-www-form-urlencoded"}]) do
+    case OAuth2.AccessToken.post(token, "/users.info", [token: token.access_token, user: auth["user_id"]], [{"Content-Type", "application/x-www-form-urlencoded"}]) do
       { :ok, %OAuth2.Response{status_code: 401, body: _body}} ->
         set_errors!(conn, [error("token", "unauthorized")])
       { :ok, %OAuth2.Response{status_code: status_code, body: user} } when status_code in 200..399 ->

--- a/mix.lock
+++ b/mix.lock
@@ -7,7 +7,7 @@
   "mimerl": {:hex, :mimerl, "1.0.0"},
   "mimetype_parser": {:hex, :mimetype_parser, "0.1.0"},
   "oauth2": {:hex, :oauth2, "0.5.0"},
-  "plug": {:hex, :plug, "1.0.2"},
+  "plug": {:hex, :plug, "1.1.3"},
   "poison": {:hex, :poison, "1.5.0"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
-  "ueberauth": {:hex, :ueberauth, "0.1.0"}}
+  "ueberauth": {:hex, :ueberauth, "0.2.0"}}


### PR DESCRIPTION
Fixes #5 

Issue was OAuth 0.6.0 removed some default headers, including that the Content-Type is application/x-www-form-urlencoded. In the absence of a header the request defaulted to application/json which didn't work with the parameters passed.
