### PR TITLE
Fix Readme for slack provider config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
     ```elixir
     config :ueberauth, Ueberauth,
       providers: [
-        slack: [{Ueberauth.Strategy.Slack, []}]
+        slack: {Ueberauth.Strategy.Slack, []}
       ]
     ```
 
@@ -36,11 +36,7 @@
     ```elixir
     config :ueberauth, Ueberauth,
       providers: [
-        slack: [
-          {Ueberauth.Strategy.Slack, [
-            team: "0ABCDEF"
-          ]}
-        ]
+        slack: {Ueberauth.Strategy.Slack, [team: "0ABCDEF"]}
       ]
     ```
 


### PR DESCRIPTION
When configuring a slack uberauth provider, the provider strategy should be provided as tuple, not a list.

https://github.com/ueberauth/ueberauth#configuring-providers
