### PR TITLE
oauth module not using client_opts in &Slack.OAuth.client/1

### DIFF
--- a/lib/ueberauth/strategy/slack/oauth.ex
+++ b/lib/ueberauth/strategy/slack/oauth.ex
@@ -16,7 +16,7 @@ defmodule Ueberauth.Strategy.Slack.OAuth do
       |> Keyword.merge(slack_config)
       |> Keyword.merge(opts)
 
-    OAuth2.Client.new(opts)
+    OAuth2.Client.new(client_opts)
   end
 
   def authorize_url!(params \\ [], opts \\ []) do


### PR DESCRIPTION
Fixes bug introduced in https://github.com/ueberauth/ueberauth_slack/commit/ef422b53ced779d7d94f97af73b1b83d6247a78e#diff-479a8720994e487712f9d71a510cfbdaR19