### PR TITLE
Enable configurable redirect_uri

### DIFF
--- a/lib/ueberauth/strategy/slack.ex
+++ b/lib/ueberauth/strategy/slack.ex
@@ -53,9 +53,10 @@ defmodule Ueberauth.Strategy.Slack do
   def handle_callback!(%Plug.Conn{params: %{"code" => code}} = conn) do
     module  = option(conn, :oauth2_module)
     params  = [code: code]
+    redirect_uri = conn |> get_redirect_uri
     options = %{
       options: [
-        client_options: [redirect_uri: callback_url(conn)]
+        client_options: [redirect_uri: redirect_uri]
       ]
     }
     token = apply(module, :get_token!, [params, options])
@@ -243,5 +244,15 @@ defmodule Ueberauth.Strategy.Slack do
 
   defp option(conn, key) do
     Dict.get(options(conn), key, Dict.get(default_options, key))
+  end
+
+  defp get_redirect_uri(%Plug.Conn{} = conn) do
+    config = Application.get_env(:ueberauth, Ueberauth)
+    redirect_uri = config |> Keyword.get(:redirect_uri)
+
+    case is_nil(redirect_uri) do
+      true -> callback_url(conn)
+      false -> redirect_uri
+    end
   end
 end

--- a/lib/ueberauth/strategy/slack.ex
+++ b/lib/ueberauth/strategy/slack.ex
@@ -53,7 +53,7 @@ defmodule Ueberauth.Strategy.Slack do
   def handle_callback!(%Plug.Conn{params: %{"code" => code}} = conn) do
     module  = option(conn, :oauth2_module)
     params  = [code: code]
-    redirect_uri = conn |> get_redirect_uri
+    redirect_uri = get_redirect_uri(conn)
     options = %{
       options: [
         client_options: [redirect_uri: redirect_uri]
@@ -248,11 +248,12 @@ defmodule Ueberauth.Strategy.Slack do
 
   defp get_redirect_uri(%Plug.Conn{} = conn) do
     config = Application.get_env(:ueberauth, Ueberauth)
-    redirect_uri = config |> Keyword.get(:redirect_uri)
+    redirect_uri = Keyword.get(config, :redirect_uri)
 
-    case is_nil(redirect_uri) do
-      true -> callback_url(conn)
-      false -> redirect_uri
+    if is_nil(redirect_uri) do
+      callback_url(conn)
+    else
+      redirect_uri
     end
   end
 end

--- a/lib/ueberauth/strategy/slack/oauth.ex
+++ b/lib/ueberauth/strategy/slack/oauth.ex
@@ -38,13 +38,6 @@ defmodule Ueberauth.Strategy.Slack.OAuth do
     options        = Dict.get(options, :options, [])
     client_options = Dict.get(options, :client_options, [])
 
-    config = Application.get_env(:ueberauth, Ueberauth)
-    redirect_uri = config |> Keyword.get(:redirect_uri)
-
-    if redirect_uri do
-      client_options ++ [redirect_uri: redirect_uri]
-    end
-
     client = OAuth2.Client.get_token!(client(client_options), params, headers, options)
 
     client.token

--- a/lib/ueberauth/strategy/slack/oauth.ex
+++ b/lib/ueberauth/strategy/slack/oauth.ex
@@ -37,7 +37,16 @@ defmodule Ueberauth.Strategy.Slack.OAuth do
     headers        = Dict.get(options, :headers, [])
     options        = Dict.get(options, :options, [])
     client_options = Dict.get(options, :client_options, [])
+
+    config = Application.get_env(:ueberauth, Ueberauth)
+    redirect_uri = config |> Keyword.get(:redirect_uri)
+
+    if redirect_uri do
+      client_options ++ [redirect_uri: redirect_uri]
+    end
+
     client = OAuth2.Client.get_token!(client(client_options), params, headers, options)
+
     client.token
   end
 


### PR DESCRIPTION
I'm currently using this lib in a JSON based API. The single page app (SPA) set's a `redirect_uri` that is a route to the SPA instead of the API so that the UI can do some other requests. This library currently assumes the `redirect_uri` is relative to the SPA, which doesn't fit my current use case.

The change here is to allow the developer to specify this redirect_uri from a config Keyword list.

## Changes

- Checks for redirect_uri key in the `Ueberauth ` config
  - if it exists, we use that value
  - if it does not exist, we use the default from client_options

## Question

- Should this redirect_uri be configurable on `config :ueberauth, Ueberauth.Strategy.Slack.OAuth` or `config :ueberauth, Ueberauth`?