### PR TITLE
Upgrade to 0.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: elixir
+elixir:
+  - 1.3
+  - 1.4
+  - 1.5
+  - 1.6
+otp_release:
+  - 19.3
+  - 20.1
+sudo: false
+env:
+  global:
+    - ELIXIR_ASSERT_TIMEOUT=2000
+before_script:
+  - mix deps.get
+script:
+  - mix test
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: elixir
 elixir:
-  - 1.3
-  - 1.4
-  - 1.5
   - 1.6
 otp_release:
   - 19.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# v 0.5.0
+
+* Pin OAuth2 to 0.8.0
+* Configurable `redirect_uri`
+* Fix bug with OAuth and `client_opts`
+* Fix Slack bug with parsing `users:read` scope
+
 # v 0.4.1
 
 * Avoid exceptions when team is missing

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
     ```elixir
     def deps do
-      [{:ueberauth_slack, "~> 0.4"}]
+      [{:ueberauth_slack, "~> 0.5"}]
     end
     ```
 

--- a/lib/ueberauth/strategy/slack.ex
+++ b/lib/ueberauth/strategy/slack.ex
@@ -253,7 +253,7 @@ defmodule Ueberauth.Strategy.Slack do
   end
 
   defp option(conn, key) do
-    Dict.get(options(conn), key, Dict.get(default_options, key))
+    Map.get(options(conn), key, Map.get(default_options(), key))
   end
 
   defp get_redirect_uri(%Plug.Conn{} = conn) do

--- a/lib/ueberauth/strategy/slack/oauth.ex
+++ b/lib/ueberauth/strategy/slack/oauth.ex
@@ -24,7 +24,7 @@ defmodule Ueberauth.Strategy.Slack.OAuth do
     |> client()
     |> to_url(url, Map.put(params, "token", token.access_token))
 
-    OAuth2.Client.get(client, url, headers, opts)
+    OAuth2.Client.get(client(), url, headers, opts)
   end
 
   def authorize_url!(params \\ [], opts \\ []) do
@@ -34,9 +34,9 @@ defmodule Ueberauth.Strategy.Slack.OAuth do
   end
 
   def get_token!(params \\ [], options \\ %{}) do
-    headers        = Dict.get(options, :headers, [])
-    options        = Dict.get(options, :options, [])
-    client_options = Dict.get(options, :client_options, [])
+    headers        = Map.get(options, :headers, [])
+    options        = Map.get(options, :options, [])
+    client_options = Map.get(options, :client_options, [])
 
     client = OAuth2.Client.get_token!(client(client_options), params, headers, options)
 
@@ -60,18 +60,18 @@ defmodule Ueberauth.Strategy.Slack.OAuth do
   defp endpoint(endpoint, _client), do: endpoint
 
   defp to_url(client, endpoint, params \\ nil) do
-    endpoint =
+    client_endpoint =
       client
       |> Map.get(endpoint, endpoint)
       |> endpoint(client)
 
-    endpoint =
+    final_endpoint =
       if params do
-        endpoint <> "?" <> URI.encode_query(params)
+        client_endpoint <> "?" <> URI.encode_query(params)
       else
-        endpoint
+        client_endpoint
       end
 
-    endpoint
+    final_endpoint
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule UeberauthSlack.Mixfile do
   use Mix.Project
 
-  @version "0.4.1"
+  @version "0.5.0"
 
   def project do
     [app: :ueberauth_slack,


### PR DESCRIPTION
Addresses Issue #27 - this was fixed, but because the version hasn't been bumped in so long, mix doesn't recognize the latest changes that must have fixed this issue.

* Updates the version to 0.5.0 based on SEMVER standards - new functionality was added since 0.4.1 (see `CHANGELOG.md`) in a backwards-compatible way, in addition to bug fixes, so this warrants an upgrade of the MINOR version
* Lists these updates in the `CHANGELOG.md` file
* Because of the MINOR version, the `README.md` file needs to be updated to reflect the new install version
* Added a `.travis.yml` file to get the repo to register as passing. There is one test and it passes, but the config file was never added/set up.

I also fixed deprecation warnings from `Dict`, `client`, and `default_options`